### PR TITLE
feature/calculated_timer_width

### DIFF
--- a/rtl/cycle_timer.sv
+++ b/rtl/cycle_timer.sv
@@ -62,7 +62,7 @@ end
 
 always_ff @(posedge clock or negedge reset_n) begin
     if (!reset_n) begin
-        counter <=  0;
+        counter <=  '1;
     end
     else begin
         counter <=  _counter;

--- a/test/case_002/case_002.svh
+++ b/test/case_002/case_002.svh
@@ -3,7 +3,7 @@
 // Engineer:      Artin Isagholian
 //                artinisagholian@gmail.com
 //
-// Create Date:    4/27/2020
+// Create Date:    5/27/2025
 // Design Name:
 // Module Name:    case_002
 // Project Name:

--- a/test/testbench.sv
+++ b/test/testbench.sv
@@ -68,7 +68,6 @@ i2c_master #(
     .NUMBER_OF_REGISTER_BYTES       (NUMBER_OF_REGISTER_BYTES),
     .ADDRESS_WIDTH                  (ADDRESS_WIDTH),
     .CHECK_FOR_CLOCK_STRETCHING     (1),
-    .CLOCK_STRETCHING_TIMER_WIDTH   (16),
     .CLOCK_STRETCHING_MAX_COUNT     ('hFF)
 ) i2c_master(
             .clock                  (i2c_master_clock),


### PR DESCRIPTION
Removed CLOCK_STRETCHING_TIMER_WIDTH parameter. Instead made it be a localparam that is calculated automatically from the CLOCK_STRETCHING_MAX_COUNT parameter.